### PR TITLE
Chore/test react 15 and 16

### DIFF
--- a/packages/react-accessible-tooltip/package.json
+++ b/packages/react-accessible-tooltip/package.json
@@ -75,5 +75,9 @@
     "setupFiles": [
       "./src/setupTests.js"
     ]
+  },
+  "dependencies": {
+    "react-15": "npm:react@15.6.1",
+    "react-16": "npm:react@16.2.0"
   }
 }

--- a/packages/react-accessible-tooltip/src/Tooltip.test.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.test.js
@@ -1,12 +1,13 @@
 // @flow
 
-import React from 'react';
 import classnames from 'classnames';
 import toJson from 'enzyme-to-json';
 import { mount } from 'enzyme';
-import { Tooltip, type LabelProps, type OverlayProps } from './';
+import React16 from 'react-16';
+import React15 from 'react-15';
+import { type LabelProps, type OverlayProps } from './';
 
-describe('<Tooltip />', () => {
+function testReact(React, Tooltip) {
     const HIDDEN_CLASS = 'HIDDEN_CLASS';
     const LABEL_CLASS = 'LABEL_CLASS';
     const OVERLAY_CLASS = 'OVERLAY_CLASS';
@@ -50,7 +51,7 @@ describe('<Tooltip />', () => {
         closeButton = wrapper.find(CloseButton);
     });
 
-    it('matches the previous snapshot', () => {
+    it(`${React.version} - asdmatches the previous snapshot`, () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
@@ -81,5 +82,21 @@ describe('<Tooltip />', () => {
 
         closeButton.simulate('click');
         expect(wrapper.state('isHidden')).toBeTruthy();
+    });
+}
+
+describe('<Tooltip />', () => {
+    describe('React 16', () => {
+        jest.resetModules();
+        jest.doMock('react', () => React16);
+        const { Tooltip } = require('./');
+        testReact(React16, Tooltip);
+    });
+
+    describe('React 15', () => {
+        jest.resetModules();
+        jest.doMock('react', () => React15);
+        const { Tooltip } = require('./');
+        testReact(React15, Tooltip);
     });
 });

--- a/packages/react-accessible-tooltip/src/__snapshots__/Tooltip.test.js.snap
+++ b/packages/react-accessible-tooltip/src/__snapshots__/Tooltip.test.js.snap
@@ -1,6 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Tooltip /> matches the previous snapshot 1`] = `
+exports[`<Tooltip /> React 15 15.6.1 - asdmatches the previous snapshot 1`] = `
+<Tooltip
+  label={[Function]}
+  overlay={[Function]}
+>
+  <div
+    onBlur={[Function]}
+  >
+    <Label
+      isHidden={true}
+      labelAttributes={
+        Object {
+          "aria-describedby": "#react-accessible-tooltip-0",
+          "onFocus": [Function],
+          "role": "tooltip",
+          "tabIndex": "0",
+        }
+      }
+      requestHide={[Function]}
+      requestShow={[Function]}
+      requestToggle={[Function]}
+    >
+      <div
+        aria-describedby="#react-accessible-tooltip-0"
+        className="LABEL_CLASS HIDDEN_CLASS"
+        onFocus={[Function]}
+        role="tooltip"
+        tabIndex="0"
+      />
+    </Label>
+    <Overlay
+      isHidden={true}
+      overlayAttributes={
+        Object {
+          "aria-hidden": true,
+          "id": "react-accessible-tooltip-0",
+          "tabIndex": "-1",
+        }
+      }
+      requestHide={[Function]}
+      requestShow={[Function]}
+      requestToggle={[Function]}
+    >
+      <div
+        aria-hidden={true}
+        className="OVERLAY_CLASS HIDDEN_CLASS"
+        id="react-accessible-tooltip-0"
+        tabIndex="-1"
+      >
+        <CloseButton
+          onClick={[Function]}
+        >
+          <button
+            onClick={[Function]}
+          >
+            close
+          </button>
+        </CloseButton>
+      </div>
+    </Overlay>
+  </div>
+</Tooltip>
+`;
+
+exports[`<Tooltip /> React 16 16.2.0 - asdmatches the previous snapshot 1`] = `
 <Tooltip
   label={[Function]}
   overlay={[Function]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,6 +1665,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-react-class@^15.6.0:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -2658,7 +2666,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.16:
+fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -5388,6 +5396,25 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+"react-15@npm:react@15.6.1":
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+  dependencies:
+    create-react-class "^15.6.0"
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
+
+"react-16@npm:react@latest":
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react-dom@^16.0.0, react-dom@^16.1.1:
   version "16.1.1"


### PR DESCRIPTION
Uses a yarn feature (dependency aliasing) to install two different versions of React, and runs each test twice - once with React 15, and once with React 16.