### PR TITLE
Ipad touch-away handling

### DIFF
--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -51,7 +51,10 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
         isHidden: true,
     };
 
-    onBlur({ relatedTarget, currentTarget }: SyntheticFocusEvent<HTMLElement>) {
+    onBlur = ({
+        relatedTarget,
+        currentTarget,
+    }: SyntheticFocusEvent<HTMLElement>): void => {
         // relatedTarget is better for React testability etc, but activeElement works as an IE11 fallback:
         const newTarget = relatedTarget || document.activeElement;
 
@@ -61,7 +64,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
         } else if (!currentTarget.contains(newTarget)) {
             this.hide();
         }
-    }
+    };
 
     hide = (): void => {
         this.setState({ isHidden: true });
@@ -115,7 +118,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
         return (
             <div
                 {...rest}
-                onBlur={e => this.onBlur(e)}
+                onBlur={this.onBlur}
                 ref={ref => {
                     if (containerRef) {
                         containerRef(ref);

--- a/packages/react-accessible-tooltip/src/__snapshots__/Tooltip.test.js.snap
+++ b/packages/react-accessible-tooltip/src/__snapshots__/Tooltip.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Tooltip /> React 15 15.6.1 - asdmatches the previous snapshot 1`] = `
+exports[`<Tooltip /> React 15 15.6.1 - matches the previous snapshot 1`] = `
 <Tooltip
   label={[Function]}
   overlay={[Function]}
@@ -64,7 +64,7 @@ exports[`<Tooltip /> React 15 15.6.1 - asdmatches the previous snapshot 1`] = `
 </Tooltip>
 `;
 
-exports[`<Tooltip /> React 16 16.2.0 - asdmatches the previous snapshot 1`] = `
+exports[`<Tooltip /> React 16 16.2.0 - matches the previous snapshot 1`] = `
 <Tooltip
   label={[Function]}
   overlay={[Function]}


### PR DESCRIPTION
Basically an upstream-retrofit of the logic from `acc-css-app` to add touch-away handling for iOS devices who don't actually trigger a 'blur' on focussed elements when touching-away from the element.

