### PR TITLE
Shift react-15 and react-16 to devDependecies.

### DIFF
--- a/packages/react-accessible-tooltip/package.json
+++ b/packages/react-accessible-tooltip/package.json
@@ -41,6 +41,8 @@
     "prettier": "^1.11.1",
     "raf": "^3.4.0",
     "react": "^16.2.0",
+    "react-15": "npm:react@15.6.1",
+    "react-16": "npm:react@16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
     "rimraf": "^2.6.2",
@@ -68,9 +70,5 @@
   },
   "jest": {
     "setupFiles": ["./src/setupTests.js"]
-  },
-  "dependencies": {
-    "react-15": "npm:react@15.6.1",
-    "react-16": "npm:react@16.2.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/ryami333/react-accessible-tooltip/issues/13.