### PR TITLE
Remove '#' character from aria-describedby attribute

### DIFF
--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -118,7 +118,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
             labelAttributes: {
                 role: 'tooltip',
                 tabIndex: '0',
-                'aria-describedby': `#${this.identifier}`,
+                'aria-describedby': this.identifier,
                 onFocus: this.show,
             },
             isHidden,

--- a/packages/react-accessible-tooltip/src/Tooltip.test.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.test.js
@@ -241,6 +241,13 @@ function testReact(React, Tooltip) {
                 removeEventListenerSpy.mockReset();
                 removeEventListenerSpy.mockRestore();
             });
+
+            it('contains matching "aria-describedby" and "id" attributes', () => {
+                const id = wrapper
+                    .find('[aria-describedby]')
+                    .prop('aria-describedby');
+                expect(wrapper.find(`#${id}`).exists()).toBe(true);
+            });
         });
     });
 }

--- a/packages/react-accessible-tooltip/src/__snapshots__/Tooltip.test.js.snap
+++ b/packages/react-accessible-tooltip/src/__snapshots__/Tooltip.test.js.snap
@@ -12,7 +12,7 @@ exports[`<Tooltip /> React 15 15.6.1 - matches the previous snapshot 1`] = `
       isHidden={true}
       labelAttributes={
         Object {
-          "aria-describedby": "#react-accessible-tooltip-0",
+          "aria-describedby": "react-accessible-tooltip-0",
           "onFocus": [Function],
           "role": "tooltip",
           "tabIndex": "0",
@@ -23,7 +23,7 @@ exports[`<Tooltip /> React 15 15.6.1 - matches the previous snapshot 1`] = `
       requestToggle={[Function]}
     >
       <div
-        aria-describedby="#react-accessible-tooltip-0"
+        aria-describedby="react-accessible-tooltip-0"
         className="LABEL_CLASS HIDDEN_CLASS"
         onFocus={[Function]}
         role="tooltip"
@@ -94,7 +94,7 @@ exports[`<Tooltip /> React 16 16.2.0 - matches the previous snapshot 1`] = `
       isHidden={true}
       labelAttributes={
         Object {
-          "aria-describedby": "#react-accessible-tooltip-0",
+          "aria-describedby": "react-accessible-tooltip-0",
           "onFocus": [Function],
           "role": "tooltip",
           "tabIndex": "0",
@@ -105,7 +105,7 @@ exports[`<Tooltip /> React 16 16.2.0 - matches the previous snapshot 1`] = `
       requestToggle={[Function]}
     >
       <div
-        aria-describedby="#react-accessible-tooltip-0"
+        aria-describedby="react-accessible-tooltip-0"
         className="LABEL_CLASS HIDDEN_CLASS"
         onFocus={[Function]}
         role="tooltip"


### PR DESCRIPTION
Spec states that 'aria-describedby' value is not a selector, but an ID value. Eg. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute