### PR TITLE
Blur element when hiding tooltip on mobile scroll

### DIFF
--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -86,6 +86,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
             !this.state.isHidden // prevent redundant state change
         ) {
             this.hide();
+            activeElement.blur();
         }
     };
 


### PR DESCRIPTION
This fixes #28 by ensuring the label loses focus when it hides on touch events.