### PR TITLE
Feature/hover functionality

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -66,7 +66,7 @@
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
     "react": "^16.2.0",
-    "react-accessible-tooltip": "1.5.2",
+    "react-accessible-tooltip": "1.5.6",
     "react-dom": "^16.2.0"
   }
 }

--- a/packages/docs/src/components/Header/Header.js
+++ b/packages/docs/src/components/Header/Header.js
@@ -6,7 +6,7 @@ import './header.scss';
 
 function Header() {
     return (
-        <header className="header">
+        <header className="header" role="banner">
             <Container>
                 <h1 className="header__title">React Accessible Tooltip</h1>
                 <h2 className="header__subtitle">Interactive Demo</h2>

--- a/packages/docs/webpack.config.js
+++ b/packages/docs/webpack.config.js
@@ -6,21 +6,19 @@ const cssnano = require('cssnano');
 
 const config = {
     entry: {
-        'src/main.js': [
-            'babel-polyfill',
-            './src/main.js',
-        ],
+        'src/main.js': ['babel-polyfill', './src/main.js'],
     },
 
-    output: process.env.NODE_ENV === 'production'
-        ? {
-            path: path.resolve(__dirname, 'dist'),
-            filename: '[name][chunkhash].js',
-        }
-        : {
-            path: '/',
-            filename: '[name]',
-        },
+    output:
+        process.env.NODE_ENV === 'production'
+            ? {
+                  path: path.resolve(__dirname, 'dist'),
+                  filename: '[name][chunkhash].js',
+              }
+            : {
+                  path: '/',
+                  filename: '[name]',
+              },
 
     module: {
         rules: [
@@ -30,10 +28,7 @@ const config = {
                     /(node_modules)/,
                     /(packages\/react-accessible-tooltip)/,
                 ],
-                use: [
-                    'babel-loader',
-                    'eslint-loader',
-                ],
+                use: ['babel-loader', 'eslint-loader'],
             },
             {
                 test: /\.scss$/,
@@ -44,10 +39,7 @@ const config = {
                         loader: 'postcss-loader',
                         options: {
                             plugins() {
-                                return [
-                                    autoprefixer,
-                                    cssnano,
-                                ];
+                                return [autoprefixer, cssnano];
                             },
                         },
                     },
@@ -92,6 +84,7 @@ const config = {
     devtool: 'source-map',
 
     devServer: {
+        host: '0.0.0.0',
         port: 3000,
         hot: true,
     },

--- a/packages/react-accessible-tooltip/package.json
+++ b/packages/react-accessible-tooltip/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.4.0",
-    "flow-bin": "^0.66.0",
+    "flow-bin": "^0.71.0",
     "flow-copy-source": "^1.3.0",
     "jest": "^22.4.2",
     "prettier": "^1.11.1",

--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -11,9 +11,6 @@ export type LabelProps = {
         onFocus: () => void,
     },
     isHidden: boolean,
-    requestHide: () => void,
-    requestShow: () => void,
-    requestToggle: () => void,
 };
 
 export type OverlayProps = {
@@ -23,9 +20,6 @@ export type OverlayProps = {
         'aria-hidden': boolean,
     },
     isHidden: boolean,
-    requestHide: () => void,
-    requestShow: () => void,
-    requestToggle: () => void,
 };
 
 export type TooltipState = {
@@ -61,6 +55,10 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
         document.removeEventListener('touchstart', this.handleTouch);
     }
 
+    onFocus = () => {
+        this.setState({ isFocussed: true });
+    };
+
     onBlur = ({
         relatedTarget,
         currentTarget,
@@ -70,9 +68,9 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
 
         // The idea of this logic is that we should only close the tooltip if focus has shifted from the tooltip AND all of its descendents.
         if (!(newTarget && newTarget instanceof HTMLElement)) {
-            this.hide();
+            this.setState({ isFocussed: false });
         } else if (!currentTarget.contains(newTarget)) {
-            this.hide();
+            this.setState({ isFocussed: false });
         }
     };
 
@@ -95,21 +93,9 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
             !this.container.contains(target) && // touch target not a tooltip descendent
             this.state.isFocused // prevent redundant state change
         ) {
-            this.hide();
+            this.setState({ isFocussed: false });
             activeElement.blur();
         }
-    };
-
-    hide = () => {
-        this.setState({ isFocussed: false });
-    };
-
-    show = () => {
-        this.setState({ isFocussed: true });
-    };
-
-    toggle = () => {
-        this.setState({ isFocussed: !this.state.isFocussed });
     };
 
     container: ?HTMLDivElement;
@@ -131,12 +117,9 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
                 role: 'tooltip',
                 tabIndex: '0',
                 'aria-describedby': this.identifier,
-                onFocus: this.show,
+                onFocus: this.onFocus,
             },
             isHidden,
-            requestHide: this.hide,
-            requestShow: this.show,
-            requestToggle: this.toggle,
         };
 
         const overlayProps: OverlayProps = {
@@ -146,9 +129,6 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
                 'aria-hidden': isHidden,
             },
             isHidden,
-            requestHide: this.hide,
-            requestShow: this.show,
-            requestToggle: this.toggle,
         };
 
         return (

--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -126,7 +126,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
             overlayAttributes: {
                 tabIndex: '-1',
                 id: this.identifier,
-                'aria-hidden': isHidden,
+                'aria-hidden': isHidden.toString(),
             },
             isHidden,
         };

--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -30,6 +30,7 @@ export type OverlayProps = {
 
 export type TooltipState = {
     isFocussed: boolean,
+    isHovered: boolean,
 };
 
 export type TooltipProps = ElementProps<'div'> & {
@@ -49,6 +50,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
 
     state = {
         isFocussed: false,
+        isHovered: false,
     };
 
     componentDidMount() {
@@ -72,6 +74,14 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
         } else if (!currentTarget.contains(newTarget)) {
             this.hide();
         }
+    };
+
+    onMouseEnter = () => {
+        this.setState({ isHovered: true });
+    };
+
+    onMouseLeave = () => {
+        this.setState({ isHovered: false });
     };
 
     // This handles the support for touch devices that do not trigger blur on 'touch-away'.
@@ -113,8 +123,8 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
             ...rest
         } = this.props;
 
-        const { isFocussed } = this.state;
-        const isHidden = isFocussed;
+        const { isFocussed, isHovered } = this.state;
+        const isHidden = isFocussed || isHovered;
 
         const labelProps: LabelProps = {
             labelAttributes: {

--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -23,7 +23,7 @@ export type OverlayProps = {
 };
 
 export type TooltipState = {
-    isFocussed: boolean,
+    isFocused: boolean,
     isHovered: boolean,
 };
 
@@ -43,7 +43,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
     }
 
     state = {
-        isFocussed: false,
+        isFocused: false,
         isHovered: false,
     };
 
@@ -56,7 +56,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
     }
 
     onFocus = () => {
-        this.setState({ isFocussed: true });
+        this.setState({ isFocused: true });
     };
 
     onBlur = ({
@@ -68,9 +68,9 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
 
         // The idea of this logic is that we should only close the tooltip if focus has shifted from the tooltip AND all of its descendents.
         if (!(newTarget && newTarget instanceof HTMLElement)) {
-            this.setState({ isFocussed: false });
+            this.setState({ isFocused: false });
         } else if (!currentTarget.contains(newTarget)) {
-            this.setState({ isFocussed: false });
+            this.setState({ isFocused: false });
         }
     };
 
@@ -93,7 +93,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
             !this.container.contains(target) && // touch target not a tooltip descendent
             this.state.isFocused // prevent redundant state change
         ) {
-            this.setState({ isFocussed: false });
+            this.setState({ isFocused: false });
             activeElement.blur();
         }
     };
@@ -109,8 +109,8 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
             ...rest
         } = this.props;
 
-        const { isFocussed, isHovered } = this.state;
-        const isHidden = !(isFocussed || isHovered);
+        const { isFocused, isHovered } = this.state;
+        const isHidden = !(isFocused || isHovered);
 
         const labelProps: LabelProps = {
             labelAttributes: {

--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -17,7 +17,7 @@ export type OverlayProps = {
     overlayAttributes: {
         tabIndex: '-1',
         id: string,
-        'aria-hidden': boolean,
+        'aria-hidden': string,
     },
     isHidden: boolean,
 };

--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -124,7 +124,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
         } = this.props;
 
         const { isFocussed, isHovered } = this.state;
-        const isHidden = isFocussed || isHovered;
+        const isHidden = !(isFocussed || isHovered);
 
         const labelProps: LabelProps = {
             labelAttributes: {
@@ -161,6 +161,8 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
                         containerRef(ref);
                     }
                 }}
+                onMouseEnter={this.onMouseEnter}
+                onMouseLeave={this.onMouseLeave}
             >
                 <Label {...labelProps} />
                 <Overlay {...overlayProps} />

--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -29,7 +29,7 @@ export type OverlayProps = {
 };
 
 export type TooltipState = {
-    isHidden: boolean,
+    isFocussed: boolean,
 };
 
 export type TooltipProps = ElementProps<'div'> & {
@@ -48,7 +48,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
     }
 
     state = {
-        isHidden: true,
+        isFocussed: false,
     };
 
     componentDidMount() {
@@ -83,7 +83,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
             target instanceof Element &&
             this.container instanceof Element &&
             !this.container.contains(target) && // touch target not a tooltip descendent
-            !this.state.isHidden // prevent redundant state change
+            this.state.isFocused // prevent redundant state change
         ) {
             this.hide();
             activeElement.blur();
@@ -91,15 +91,15 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
     };
 
     hide = () => {
-        this.setState({ isHidden: true });
+        this.setState({ isFocussed: false });
     };
 
     show = () => {
-        this.setState({ isHidden: false });
+        this.setState({ isFocussed: true });
     };
 
     toggle = () => {
-        this.setState({ isHidden: !this.state.isHidden });
+        this.setState({ isFocussed: !this.state.isFocussed });
     };
 
     container: ?HTMLDivElement;
@@ -113,7 +113,8 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
             ...rest
         } = this.props;
 
-        const { isHidden } = this.state;
+        const { isFocussed } = this.state;
+        const isHidden = isFocussed;
 
         const labelProps: LabelProps = {
             labelAttributes: {
@@ -132,7 +133,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
             overlayAttributes: {
                 tabIndex: '-1',
                 id: this.identifier,
-                'aria-hidden': this.state.isHidden,
+                'aria-hidden': isHidden,
             },
             isHidden,
             requestHide: this.hide,

--- a/packages/react-accessible-tooltip/src/Tooltip.test.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.test.js
@@ -41,6 +41,8 @@ function testReact(React, Tooltip) {
     let wrapper;
     let label;
     let overlay;
+    let labelDiv;
+    let overlayDiv;
 
     function isOverlayHidden() {
         return (
@@ -57,6 +59,8 @@ function testReact(React, Tooltip) {
 
         label = wrapper.find(Label);
         overlay = wrapper.find(Overlay);
+        labelDiv = wrapper.find(`.${LABEL_CLASS}`).instance();
+        overlayDiv = wrapper.find(`.${OVERLAY_CLASS}`).instance();
     });
 
     afterEach(() => {
@@ -138,63 +142,28 @@ function testReact(React, Tooltip) {
         });
 
         describe('touch devices -', () => {
-            // let containerRef;
-            let labelRef;
-            let overlayRef;
-
-            beforeAll(() => {
-                const testRoot = document.createElement('div');
-                ReactDOM.render(
-                    <div
-                    // ref={_containerRef => {
-                    //     containerRef = _containerRef;
-                    // }}
-                    >
-                        <Tooltip
-                            label={({ labelAttributes }) => (
-                                <div
-                                    {...labelAttributes}
-                                    ref={_labelRef => {
-                                        labelRef = _labelRef;
-                                    }}
-                                />
-                            )}
-                            overlay={({ overlayAttributes }) => (
-                                <div
-                                    {...overlayAttributes}
-                                    ref={_overlayRef => {
-                                        overlayRef = _overlayRef;
-                                    }}
-                                />
-                            )}
-                        />
-                    </div>,
-                    testRoot,
-                );
-            });
-
             it('opens on focus', () => {
-                expect(overlayRef.getAttribute('aria-hidden')).toEqual('true');
-                Simulate.focus(labelRef);
-                expect(overlayRef.getAttribute('aria-hidden')).toEqual('false');
+                expect(isOverlayHidden()).toBeTruthy();
+                Simulate.focus(labelDiv);
+                expect(isOverlayHidden()).toBeFalsy();
             });
 
             it('closes on touch-away', () => {
-                Simulate.focus(labelRef);
-                expect(overlayRef.getAttribute('aria-hidden')).toEqual('false');
+                Simulate.focus(labelDiv);
+                expect(isOverlayHidden()).toBeFalsy();
                 const testEvent = new Event('touchstart', { bubbles: true });
                 // $FlowFixMe
                 document.body.dispatchEvent(testEvent);
-                expect(overlayRef.getAttribute('aria-hidden')).toEqual('true');
+                expect(isOverlayHidden()).toBeTruthy();
             });
 
             it("doesn't close when descendant element touched", () => {
-                Simulate.focus(labelRef);
-                expect(overlayRef.getAttribute('aria-hidden')).toEqual('false');
+                Simulate.focus(labelDiv);
+                expect(isOverlayHidden()).toBeFalsy();
                 const testEvent = new Event('touchstart', { bubbles: true });
                 // $FlowFixMe;
-                overlayRef.dispatchEvent(testEvent);
-                expect(overlayRef.getAttribute('aria-hidden')).toEqual('false');
+                overlayDiv.dispatchEvent(testEvent);
+                expect(isOverlayHidden()).toBeFalsy();
             });
 
             it('successfully unmounts without crashing', () => {

--- a/packages/react-accessible-tooltip/src/Tooltip.test.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.test.js
@@ -137,6 +137,23 @@ function testReact(React, Tooltip) {
             );
         });
 
+        describe('hover functionality', () => {
+            it('opens on mouseEnter and closes on mouseLeave', () => {
+                expect(isOverlayHidden()).toBeTruthy();
+                wrapper
+                    .find('div')
+                    .first()
+                    .simulate('mouseEnter');
+                expect(isOverlayHidden()).toBeFalsy();
+
+                wrapper
+                    .find('div')
+                    .first()
+                    .simulate('mouseLeave');
+                expect(isOverlayHidden()).toBeTruthy();
+            });
+        });
+
         describe('touch devices -', () => {
             it('opens on focus', () => {
                 expect(isOverlayHidden()).toBeTruthy();

--- a/packages/react-accessible-tooltip/src/Tooltip.test.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.test.js
@@ -137,10 +137,6 @@ function testReact(React, Tooltip) {
             );
         });
 
-        it('respects a user-generated toggle', () => {
-            wrapper = mount(<Tooltip label={Label} overlay={Overlay} />);
-        });
-
         describe('touch devices -', () => {
             it('opens on focus', () => {
                 expect(isOverlayHidden()).toBeTruthy();

--- a/packages/react-accessible-tooltip/src/Tooltip.test.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.test.js
@@ -27,44 +27,26 @@ function testReact(React, Tooltip) {
         />
     );
 
-    const CloseButton = props => <button {...props} />;
-    const ToggleButton = props => <button {...props} />;
-    const ShowButton = props => <button {...props} />;
-
-    const Overlay = ({
-        isHidden,
-        requestHide,
-        requestToggle,
-        requestShow,
-        overlayAttributes,
-    }: OverlayProps) => (
+    const Overlay = ({ isHidden, overlayAttributes }: OverlayProps) => (
         <div
             className={classnames(OVERLAY_CLASS, {
                 [HIDDEN_CLASS]: isHidden,
             })}
             {...overlayAttributes}
         >
-            <CloseButton onClick={requestHide}>close</CloseButton>
-            <ToggleButton onClick={requestToggle}>toggle</ToggleButton>
-            <ShowButton onClick={requestShow}>toggle</ShowButton>
+            Hello world
         </div>
     );
 
     let wrapper;
     let label;
     let overlay;
-    let closeButton;
-    let toggleButton;
-    let showButton;
 
     beforeEach(() => {
         wrapper = mount(<Tooltip label={Label} overlay={Overlay} />);
 
         label = wrapper.find(Label);
         overlay = wrapper.find(Overlay);
-        closeButton = wrapper.find(CloseButton);
-        toggleButton = wrapper.find(ToggleButton);
-        showButton = wrapper.find(ShowButton);
     });
 
     describe(`${React.version} -`, () => {
@@ -117,32 +99,6 @@ function testReact(React, Tooltip) {
             label.simulate('focus');
             expect(wrapper.state('isHidden')).toBeFalsy();
             label.simulate('blur', { relatedTarget: overlay.getDOMNode() });
-            expect(wrapper.state('isHidden')).toBeFalsy();
-        });
-
-        it('respects a manual close request', () => {
-            label.simulate('focus');
-            expect(wrapper.state('isHidden')).toBeFalsy();
-
-            closeButton.simulate('click');
-            expect(wrapper.state('isHidden')).toBeTruthy();
-        });
-
-        it('respects a manual toggle request', () => {
-            label.simulate('focus');
-            expect(wrapper.state('isHidden')).toBeFalsy();
-
-            toggleButton.simulate('click');
-            expect(wrapper.state('isHidden')).toBeTruthy();
-            toggleButton.simulate('click');
-            expect(wrapper.state('isHidden')).toBeFalsy();
-        });
-
-        it('respects a manual show request', () => {
-            expect(wrapper.state('isHidden')).toBeTruthy();
-            showButton.simulate('click');
-            expect(wrapper.state('isHidden')).toBeFalsy();
-            showButton.simulate('click');
             expect(wrapper.state('isHidden')).toBeFalsy();
         });
 

--- a/packages/react-accessible-tooltip/src/Tooltip.test.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.test.js
@@ -59,6 +59,10 @@ function testReact(React, Tooltip) {
         overlay = wrapper.find(Overlay);
     });
 
+    afterEach(() => {
+        wrapper.unmount();
+    });
+
     describe(`${React.version} -`, () => {
         it('matches the previous snapshot', () => {
             expect(toJson(wrapper)).toMatchSnapshot();

--- a/packages/react-accessible-tooltip/src/Tooltip.test.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.test.js
@@ -39,7 +39,6 @@ function testReact(React, Tooltip) {
     let wrapper;
     let label;
     let overlay;
-    let labelDiv;
     let overlayDiv;
 
     function isOverlayHidden() {
@@ -57,7 +56,6 @@ function testReact(React, Tooltip) {
 
         label = wrapper.find(Label);
         overlay = wrapper.find(Overlay);
-        labelDiv = wrapper.find(`.${LABEL_CLASS}`).instance();
         overlayDiv = wrapper.find(`.${OVERLAY_CLASS}`).instance();
     });
 

--- a/packages/react-accessible-tooltip/src/Tooltip.test.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.test.js
@@ -3,8 +3,6 @@
 import classnames from 'classnames';
 import toJson from 'enzyme-to-json';
 import { mount } from 'enzyme';
-import { Simulate } from 'react-dom/test-utils';
-import ReactDOM from 'react-dom';
 
 // $FlowFixMe
 import React16 from 'react-16';
@@ -157,12 +155,12 @@ function testReact(React, Tooltip) {
         describe('touch devices -', () => {
             it('opens on focus', () => {
                 expect(isOverlayHidden()).toBeTruthy();
-                Simulate.focus(labelDiv);
+                label.simulate('focus');
                 expect(isOverlayHidden()).toBeFalsy();
             });
 
             it('closes on touch-away', () => {
-                Simulate.focus(labelDiv);
+                label.simulate('focus');
                 expect(isOverlayHidden()).toBeFalsy();
                 const testEvent = new Event('touchstart', { bubbles: true });
                 // $FlowFixMe
@@ -171,7 +169,7 @@ function testReact(React, Tooltip) {
             });
 
             it("doesn't close when descendant element touched", () => {
-                Simulate.focus(labelDiv);
+                label.simulate('focus');
                 expect(isOverlayHidden()).toBeFalsy();
                 const testEvent = new Event('touchstart', { bubbles: true });
                 // $FlowFixMe;

--- a/packages/react-accessible-tooltip/src/Tooltip.test.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.test.js
@@ -42,6 +42,16 @@ function testReact(React, Tooltip) {
     let label;
     let overlay;
 
+    function isOverlayHidden() {
+        return (
+            wrapper
+                .find(Overlay)
+                .find('div')
+                .instance()
+                .getAttribute('aria-hidden') === 'true'
+        );
+    }
+
     beforeEach(() => {
         wrapper = mount(<Tooltip label={Label} overlay={Overlay} />);
 
@@ -61,45 +71,45 @@ function testReact(React, Tooltip) {
         });
 
         it('hides the overlay by default', () => {
-            expect(wrapper.state('isHidden')).toBeTruthy();
+            expect(isOverlayHidden()).toBeTruthy();
         });
 
         it('reveals the overlay when the label is focussed', () => {
-            expect(wrapper.state('isHidden')).toBeTruthy();
+            expect(isOverlayHidden()).toBeTruthy();
             label.simulate('focus');
-            expect(wrapper.state('isHidden')).toBeFalsy();
+            expect(isOverlayHidden()).toBeFalsy();
         });
 
         it('hides the overlay when the whole tooltip is blurred (and focus changes to a non-recognisable target)', () => {
-            expect(wrapper.state('isHidden')).toBeTruthy();
+            expect(isOverlayHidden()).toBeTruthy();
             label.simulate('focus');
-            expect(wrapper.state('isHidden')).toBeFalsy();
+            expect(isOverlayHidden()).toBeFalsy();
             label.simulate('blur', { relatedTarget: 'notAnElement' });
-            expect(wrapper.state('isHidden')).toBeTruthy();
+            expect(isOverlayHidden()).toBeTruthy();
         });
 
         it("hides the overlay when focus shifts and there's no support for event.relatedTarget", () => {
-            expect(wrapper.state('isHidden')).toBeTruthy();
+            expect(isOverlayHidden()).toBeTruthy();
             label.simulate('focus');
-            expect(wrapper.state('isHidden')).toBeFalsy();
+            expect(isOverlayHidden()).toBeFalsy();
             label.simulate('blur');
-            expect(wrapper.state('isHidden')).toBeTruthy();
+            expect(isOverlayHidden()).toBeTruthy();
         });
 
         it('hides the overlay when focus shifts to a target outside the tooltip', () => {
-            expect(wrapper.state('isHidden')).toBeTruthy();
+            expect(isOverlayHidden()).toBeTruthy();
             label.simulate('focus');
-            expect(wrapper.state('isHidden')).toBeFalsy();
+            expect(isOverlayHidden()).toBeFalsy();
             label.simulate('blur', { relatedTarget: document.body });
-            expect(wrapper.state('isHidden')).toBeTruthy();
+            expect(isOverlayHidden()).toBeTruthy();
         });
 
         it("doesn't hide the overlay when focus shifts to the tooltip overlay", () => {
-            expect(wrapper.state('isHidden')).toBeTruthy();
+            expect(isOverlayHidden()).toBeTruthy();
             label.simulate('focus');
-            expect(wrapper.state('isHidden')).toBeFalsy();
+            expect(isOverlayHidden()).toBeFalsy();
             label.simulate('blur', { relatedTarget: overlay.getDOMNode() });
-            expect(wrapper.state('isHidden')).toBeFalsy();
+            expect(isOverlayHidden()).toBeFalsy();
         });
 
         it('respects the containerRef prop', () => {

--- a/packages/react-accessible-tooltip/src/__snapshots__/Tooltip.test.js.snap
+++ b/packages/react-accessible-tooltip/src/__snapshots__/Tooltip.test.js.snap
@@ -7,6 +7,8 @@ exports[`<Tooltip /> React 15 15.6.1 - matches the previous snapshot 1`] = `
 >
   <div
     onBlur={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <Label
       isHidden={true}
@@ -18,9 +20,6 @@ exports[`<Tooltip /> React 15 15.6.1 - matches the previous snapshot 1`] = `
           "tabIndex": "0",
         }
       }
-      requestHide={[Function]}
-      requestShow={[Function]}
-      requestToggle={[Function]}
     >
       <div
         aria-describedby="react-accessible-tooltip-0"
@@ -39,9 +38,6 @@ exports[`<Tooltip /> React 15 15.6.1 - matches the previous snapshot 1`] = `
           "tabIndex": "-1",
         }
       }
-      requestHide={[Function]}
-      requestShow={[Function]}
-      requestToggle={[Function]}
     >
       <div
         aria-hidden={true}
@@ -49,33 +45,7 @@ exports[`<Tooltip /> React 15 15.6.1 - matches the previous snapshot 1`] = `
         id="react-accessible-tooltip-0"
         tabIndex="-1"
       >
-        <CloseButton
-          onClick={[Function]}
-        >
-          <button
-            onClick={[Function]}
-          >
-            close
-          </button>
-        </CloseButton>
-        <ToggleButton
-          onClick={[Function]}
-        >
-          <button
-            onClick={[Function]}
-          >
-            toggle
-          </button>
-        </ToggleButton>
-        <ShowButton
-          onClick={[Function]}
-        >
-          <button
-            onClick={[Function]}
-          >
-            toggle
-          </button>
-        </ShowButton>
+        Hello world
       </div>
     </Overlay>
   </div>
@@ -89,6 +59,8 @@ exports[`<Tooltip /> React 16 16.2.0 - matches the previous snapshot 1`] = `
 >
   <div
     onBlur={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <Label
       isHidden={true}
@@ -100,9 +72,6 @@ exports[`<Tooltip /> React 16 16.2.0 - matches the previous snapshot 1`] = `
           "tabIndex": "0",
         }
       }
-      requestHide={[Function]}
-      requestShow={[Function]}
-      requestToggle={[Function]}
     >
       <div
         aria-describedby="react-accessible-tooltip-0"
@@ -121,9 +90,6 @@ exports[`<Tooltip /> React 16 16.2.0 - matches the previous snapshot 1`] = `
           "tabIndex": "-1",
         }
       }
-      requestHide={[Function]}
-      requestShow={[Function]}
-      requestToggle={[Function]}
     >
       <div
         aria-hidden={true}
@@ -131,33 +97,7 @@ exports[`<Tooltip /> React 16 16.2.0 - matches the previous snapshot 1`] = `
         id="react-accessible-tooltip-0"
         tabIndex="-1"
       >
-        <CloseButton
-          onClick={[Function]}
-        >
-          <button
-            onClick={[Function]}
-          >
-            close
-          </button>
-        </CloseButton>
-        <ToggleButton
-          onClick={[Function]}
-        >
-          <button
-            onClick={[Function]}
-          >
-            toggle
-          </button>
-        </ToggleButton>
-        <ShowButton
-          onClick={[Function]}
-        >
-          <button
-            onClick={[Function]}
-          >
-            toggle
-          </button>
-        </ShowButton>
+        Hello world
       </div>
     </Overlay>
   </div>

--- a/packages/react-accessible-tooltip/src/__snapshots__/Tooltip.test.js.snap
+++ b/packages/react-accessible-tooltip/src/__snapshots__/Tooltip.test.js.snap
@@ -33,14 +33,14 @@ exports[`<Tooltip /> React 15 15.6.1 - matches the previous snapshot 1`] = `
       isHidden={true}
       overlayAttributes={
         Object {
-          "aria-hidden": true,
+          "aria-hidden": "true",
           "id": "react-accessible-tooltip-0",
           "tabIndex": "-1",
         }
       }
     >
       <div
-        aria-hidden={true}
+        aria-hidden="true"
         className="OVERLAY_CLASS HIDDEN_CLASS"
         id="react-accessible-tooltip-0"
         tabIndex="-1"
@@ -85,14 +85,14 @@ exports[`<Tooltip /> React 16 16.2.0 - matches the previous snapshot 1`] = `
       isHidden={true}
       overlayAttributes={
         Object {
-          "aria-hidden": true,
+          "aria-hidden": "true",
           "id": "react-accessible-tooltip-0",
           "tabIndex": "-1",
         }
       }
     >
       <div
-        aria-hidden={true}
+        aria-hidden="true"
         className="OVERLAY_CLASS HIDDEN_CLASS"
         id="react-accessible-tooltip-0"
         tabIndex="-1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3136,9 +3136,9 @@ flow-bin@^0.57.3:
   version "0.57.3"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.3.tgz#843fb80a821b6d0c5847f7bb3f42365ffe53b27b"
 
-flow-bin@^0.66.0:
-  version "0.66.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.66.0.tgz#a96dde7015dc3343fd552a7b4963c02be705ca26"
+flow-bin@^0.71.0:
+  version "0.71.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.71.0.tgz#fd1b27a6458c3ebaa5cb811853182ed631918b70"
 
 flow-copy-source@^1.3.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6163,13 +6163,6 @@ rc@^1.1.7:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-accessible-tooltip@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/react-accessible-tooltip/-/react-accessible-tooltip-1.5.2.tgz#7f6ed7883515e18bfe5f37231285b1d5953434d3"
-  dependencies:
-    react-15 "npm:react@15.6.1"
-    react-16 "npm:react@16.2.0"
-
 react-dom@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"


### PR DESCRIPTION
Title says it all really - augments the library with hover functionality.

Biggest point of note is that it makes the `requestClose`, `requestOpen` and `requestToggle` callbacks incredibly difficult to continue to support, so I have removed them, meaning this will require a 'major' release.