### PR TITLE
Shift 'role=tooltip' from label to overlay

### DIFF
--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -5,7 +5,6 @@ import type { ElementProps, ComponentType } from 'react';
 
 export type LabelProps = {
     labelAttributes: {
-        role: 'tooltip',
         tabIndex: '0',
         'aria-describedby': string,
         onFocus: () => void,
@@ -15,6 +14,7 @@ export type LabelProps = {
 
 export type OverlayProps = {
     overlayAttributes: {
+        role: 'tooltip',
         tabIndex: '-1',
         id: string,
         'aria-hidden': string,
@@ -114,7 +114,6 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
 
         const labelProps: LabelProps = {
             labelAttributes: {
-                role: 'tooltip',
                 tabIndex: '0',
                 'aria-describedby': this.identifier,
                 onFocus: this.onFocus,
@@ -124,6 +123,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
 
         const overlayProps: OverlayProps = {
             overlayAttributes: {
+                role: 'tooltip',
                 tabIndex: '-1',
                 id: this.identifier,
                 'aria-hidden': isHidden.toString(),

--- a/packages/react-accessible-tooltip/src/__snapshots__/Tooltip.test.js.snap
+++ b/packages/react-accessible-tooltip/src/__snapshots__/Tooltip.test.js.snap
@@ -16,7 +16,6 @@ exports[`<Tooltip /> React 15 15.6.1 - matches the previous snapshot 1`] = `
         Object {
           "aria-describedby": "react-accessible-tooltip-0",
           "onFocus": [Function],
-          "role": "tooltip",
           "tabIndex": "0",
         }
       }
@@ -25,7 +24,6 @@ exports[`<Tooltip /> React 15 15.6.1 - matches the previous snapshot 1`] = `
         aria-describedby="react-accessible-tooltip-0"
         className="LABEL_CLASS HIDDEN_CLASS"
         onFocus={[Function]}
-        role="tooltip"
         tabIndex="0"
       />
     </Label>
@@ -35,6 +33,7 @@ exports[`<Tooltip /> React 15 15.6.1 - matches the previous snapshot 1`] = `
         Object {
           "aria-hidden": "true",
           "id": "react-accessible-tooltip-0",
+          "role": "tooltip",
           "tabIndex": "-1",
         }
       }
@@ -43,6 +42,7 @@ exports[`<Tooltip /> React 15 15.6.1 - matches the previous snapshot 1`] = `
         aria-hidden="true"
         className="OVERLAY_CLASS HIDDEN_CLASS"
         id="react-accessible-tooltip-0"
+        role="tooltip"
         tabIndex="-1"
       >
         Hello world
@@ -68,7 +68,6 @@ exports[`<Tooltip /> React 16 16.2.0 - matches the previous snapshot 1`] = `
         Object {
           "aria-describedby": "react-accessible-tooltip-0",
           "onFocus": [Function],
-          "role": "tooltip",
           "tabIndex": "0",
         }
       }
@@ -77,7 +76,6 @@ exports[`<Tooltip /> React 16 16.2.0 - matches the previous snapshot 1`] = `
         aria-describedby="react-accessible-tooltip-0"
         className="LABEL_CLASS HIDDEN_CLASS"
         onFocus={[Function]}
-        role="tooltip"
         tabIndex="0"
       />
     </Label>
@@ -87,6 +85,7 @@ exports[`<Tooltip /> React 16 16.2.0 - matches the previous snapshot 1`] = `
         Object {
           "aria-hidden": "true",
           "id": "react-accessible-tooltip-0",
+          "role": "tooltip",
           "tabIndex": "-1",
         }
       }
@@ -95,6 +94,7 @@ exports[`<Tooltip /> React 16 16.2.0 - matches the previous snapshot 1`] = `
         aria-hidden="true"
         className="OVERLAY_CLASS HIDDEN_CLASS"
         id="react-accessible-tooltip-0"
+        role="tooltip"
         tabIndex="-1"
       >
         Hello world


### PR DESCRIPTION
According to accessibility review, `role="tooltip"` should be on the overlay and not the label.