### PR TITLE
Drop support for containerRef prop

### DIFF
--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -30,7 +30,6 @@ export type TooltipState = {
 export type TooltipProps = ElementProps<'div'> & {
     label: ComponentType<LabelProps>,
     overlay: ComponentType<OverlayProps>,
-    containerRef?: HTMLDivElement => void,
 };
 
 let counter = 0;
@@ -102,12 +101,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
     identifier: string;
 
     render() {
-        const {
-            label: Label,
-            overlay: Overlay,
-            containerRef,
-            ...rest
-        } = this.props;
+        const { label: Label, overlay: Overlay, ...rest } = this.props;
 
         const { isFocused, isHovered } = this.state;
         const isHidden = !(isFocused || isHovered);
@@ -137,9 +131,6 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
                 onBlur={this.onBlur}
                 ref={ref => {
                     this.container = ref;
-                    if (containerRef) {
-                        containerRef(ref);
-                    }
                 }}
                 onMouseEnter={this.onMouseEnter}
                 onMouseLeave={this.onMouseLeave}

--- a/packages/react-accessible-tooltip/src/Tooltip.test.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.test.js
@@ -116,23 +116,6 @@ function testReact(React, Tooltip) {
             expect(isOverlayHidden()).toBeFalsy();
         });
 
-        it('respects the containerRef prop', () => {
-            const containerRef = jest.fn();
-
-            wrapper = mount(
-                <Tooltip
-                    label={Label}
-                    overlay={Overlay}
-                    containerRef={containerRef}
-                />,
-            );
-
-            expect(containerRef.mock.calls.length).toEqual(1);
-            expect(containerRef.mock.calls[0][0]).toBeInstanceOf(
-                HTMLDivElement,
-            );
-        });
-
         describe('hover functionality', () => {
             it('opens on mouseEnter and closes on mouseLeave', () => {
                 expect(isOverlayHidden()).toBeTruthy();


### PR DESCRIPTION
Next release is going to be a 'major' one, so I'm taking the opportunity to drop an undocumented feature which we _were_ using as a workaround for another known bug. That bug is now addressed (touch-away on iOS devices) so shedding some (minor) technical debt.