### PR TITLE
Fix iOS issue where tooltip would never show

### DIFF
--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -96,6 +96,14 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
         ) {
             this.setState({ isFocused: false });
             activeElement.blur();
+        } else if (
+            activeElement instanceof Element &&
+            target instanceof Element &&
+            this.container instanceof Element &&
+            this.container.contains(target) && // touch target is on tooltip descendant
+            !this.state.isFocused // prevent redundant state change
+        ) {
+            this.setState({ isFocused: true });
         }
     };
 


### PR DESCRIPTION
Apparently iOS needs styling `cursor: pointer;` to allow focus on an element and/or have a ghost hovering cursor over an element. Since the tooltip relied on focus or hover to happen to display the tooltip content, the content was never shown unless you define the `cursor: pointer;` style.

Since it's a mobile-only bug and we already listen to touch events to handle the `isFocused` component state, I added a condition where it would be set to `true` when touching inside the tooltip container.

Tested on iOS, 
Firefox and default browser on Android, 
Chrome, Firefox and Safari on OSX, 
IE 11 and Chrome on Windows 7.