### PR TITLE
Fix bug on iOs which prevented tooltip closing.

### DIFF
--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -97,8 +97,8 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
             if (this.state.isFocused) {
                 this.setState({ isFocused: false });
             }
+            // prevent redundant state change
             if (this.state.isHovered) {
-                // prevent redundant state change
                 this.setState({ isHovered: false });
             }
             // don't blur active element if outside

--- a/packages/react-accessible-tooltip/src/Tooltip.js
+++ b/packages/react-accessible-tooltip/src/Tooltip.js
@@ -91,11 +91,20 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
             activeElement instanceof Element &&
             target instanceof Element &&
             this.container instanceof Element &&
-            !this.container.contains(target) && // touch target not a tooltip descendent
-            this.state.isFocused // prevent redundant state change
+            !this.container.contains(target) // touch target not a tooltip descendent
         ) {
-            this.setState({ isFocused: false });
-            activeElement.blur();
+            // prevent redundant state change
+            if (this.state.isFocused) {
+                this.setState({ isFocused: false });
+            }
+            if (this.state.isHovered) {
+                // prevent redundant state change
+                this.setState({ isHovered: false });
+            }
+            // don't blur active element if outside
+            if (this.container.contains(activeElement)) {
+                activeElement.blur();
+            }
         } else if (
             activeElement instanceof Element &&
             target instanceof Element &&


### PR DESCRIPTION
Under certain conditions on iOS, the invisible cursor would hover the label but not move when the user touches somewhere else, thus setting `isHovered` to `true` and not set to `false` when touching away. We have to manually set it to false.