### PR TITLE
Lessened the gap between tooltip and hotspot.

### DIFF
--- a/packages/docs/src/components/Tooltip/tooltip.scss
+++ b/packages/docs/src/components/Tooltip/tooltip.scss
@@ -1,6 +1,8 @@
 @import '../../styles/settings';
 @import '../../styles/mixins';
 
+$triangle-size: 16px;
+
 .tooltip {
     display: inline-block;
     position: relative;
@@ -20,7 +22,7 @@
         left: 50%;
         margin-left: - $width / 2;
         color: $color-white;
-        padding-bottom: 30px;
+        padding-bottom: $triangle-size;
 
 
         &--hidden {
@@ -36,15 +38,15 @@
         padding: $spacing-gutter;
 
         &::before {
-            $size: 16px;
             position: absolute;
             display: block;
             content: '';
             left: 50%;
             right: 0;
             top: 100%;
-            border: $size solid transparent;
-            margin-left: -$size;
+            border: $triangle-size solid transparent;
+            border-bottom: 0;
+            margin-left: -$triangle-size;
             border-top-color: $color-brand-dark;
             width: 0;
             height: 0;


### PR DESCRIPTION
This fixes #38 and tested on:
- [x] Edge
- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] and IE!

From:
![screen shot 2018-10-16 at 3 13 09 pm](https://user-images.githubusercontent.com/1410147/46989221-c1969a80-d158-11e8-8cd8-8619ed3cdc4f.png)

To:
![screen shot 2018-10-16 at 3 27 13 pm](https://user-images.githubusercontent.com/1410147/46989226-c6f3e500-d158-11e8-9105-3651bb18c04d.png)
